### PR TITLE
[Security] Arbitrary File Read via XXE

### DIFF
--- a/lib/perfSONAR_PS/Common.pm
+++ b/lib/perfSONAR_PS/Common.pm
@@ -829,7 +829,7 @@ sub consultArchive {
 
     my $doc;
     eval {
-        my $parser = XML::LibXML->new();
+        my $parser = XML::LibXML->new(ext_ent_handler => sub { return ""; });
         $doc = $parser->parse_string( $response );
     };
     if ( $EVAL_ERROR ) {


### PR DESCRIPTION
LibXML allows the loading of external entities by default allowing unauthenticated arbitrary file read from the system using XXE.

This patch disables external entity processing by creating a `ext_ent_handler` that returns an empty string.