### PR TITLE
Adding support for sliprand

### DIFF
--- a/lib/perfSONAR_PS/Client/PScheduler/ApiFilters.pm
+++ b/lib/perfSONAR_PS/Client/PScheduler/ApiFilters.pm
@@ -140,19 +140,19 @@ sub schedule_repeat{
     return $self->task_filters->{'schedule'}->{'repeat'};
 }
 
-sub schedule_randslip{
+sub schedule_sliprand{
     my ($self, $val) = @_;
     
     if(defined $val){
         $self->_init_filter($self->task_filters, 'schedule');
-        $self->task_filters->{'schedule'}->{'randslip'} = $val;
+        $self->task_filters->{'schedule'}->{'sliprand'} = $val ? JSON::true : JSON::false;
     }
     
     unless($self->_has_filter($self->task_filters, "schedule")){
         return undef;
     }
     
-    return $self->task_filters->{'schedule'}->{'randslip'};
+    return $self->task_filters->{'schedule'}->{'sliprand'};
 }
 
 sub schedule_slip{

--- a/lib/perfSONAR_PS/Client/PScheduler/Task.pm
+++ b/lib/perfSONAR_PS/Client/PScheduler/Task.pm
@@ -145,19 +145,19 @@ sub schedule_repeat{
     return $self->data->{'schedule'}->{'repeat'};
 }
 
-sub schedule_randslip{
+sub schedule_sliprand{
     my ($self, $val) = @_;
     
     if(defined $val){
         $self->_init_field($self->data, 'schedule');
-        $self->data->{'schedule'}->{'randslip'} = $val;
+        $self->data->{'schedule'}->{'sliprand'} = $val ? JSON::true : JSON::false;
     }
     
     unless($self->_has_field($self->data, "schedule")){
         return undef;
     }
     
-    return $self->data->{'schedule'}->{'randslip'};
+    return $self->data->{'schedule'}->{'sliprand'};
 }
 
 sub schedule_slip{

--- a/lib/perfSONAR_PS/Client/PScheduler/TaskManager.pm
+++ b/lib/perfSONAR_PS/Client/PScheduler/TaskManager.pm
@@ -485,7 +485,7 @@ sub _print_task {
         print "    repeat: " . $task->schedule_repeat() . "\n" if(defined $task->schedule_repeat());
         print "    max runs: " . $task->schedule_maxruns() . "\n" if(defined $task->schedule_maxruns());
         print "    slip: " . $task->schedule_slip() . "\n" if(defined $task->schedule_slip());
-        print "    randslip: " . $task->schedule_randslip() . "\n" if(defined $task->schedule_randslip());
+        print "    sliprand: " . $task->schedule_sliprand() . "\n" if(defined $task->schedule_sliprand());
         print "    start: " . $task->schedule_start() . "\n" if(defined $task->schedule_start());
         print "    until: " . $task->schedule_until() . "\n" if(defined $task->schedule_until());
     }

--- a/lib/perfSONAR_PS/RegularTesting/Schedulers/RegularInterval.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Schedulers/RegularInterval.pm
@@ -15,6 +15,10 @@ has 'interval' => (is => 'rw', isa => 'Int');
 
 has 'random_start_percentage' => (is => 'rw', isa => 'Int');
 
+has 'slip' => (is => 'rw', isa => 'Int');
+
+has 'slip_randomize' => (is => 'rw', isa => 'Bool', default => 1);
+
 has '_next_run_time'  => (is => 'rw', isa => 'Int');
 
 my $logger = get_logger(__PACKAGE__);

--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwctl.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwctl.pm
@@ -230,12 +230,7 @@ override 'build_pscheduler_task' => sub {
     $psc_task->test_spec($psc_test_spec);
     #TODO: Support for more scheduling params
     if ($schedule->type eq "regular_intervals") {
-        $psc_task->schedule_repeat('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
-         my $randslip = .1;
-         $randslip = $schedule->random_start_percentage/100.0 if(defined $schedule->random_start_percentage);
-         $psc_task->schedule_randslip($randslip);
-         #allow a test to be scheduled anytime before the next scheduled run
-         $psc_task->schedule_slip('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
+        $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
         $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;

--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwping.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwping.pm
@@ -214,10 +214,7 @@ override 'build_pscheduler_task' => sub {
     
     #TODO: Support for more scheduling params
     if ($schedule->type eq "regular_intervals") {
-        $psc_task->schedule_repeat('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
-        $psc_task->schedule_randslip($schedule->random_start_percentage/100.0) if(defined $schedule->random_start_percentage);
-        #allow a test to be scheduled anytime before the next scheduled run
-        $psc_task->schedule_slip('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
+        $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
         $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;

--- a/lib/perfSONAR_PS/RegularTesting/Tests/BwpingOwamp.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/BwpingOwamp.pm
@@ -191,10 +191,7 @@ override 'build_pscheduler_task' => sub {
     
     #TODO: Support for more scheduling params
     if ($schedule->type eq "regular_intervals") {
-        $psc_task->schedule_repeat('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
-        $psc_task->schedule_randslip($schedule->random_start_percentage/100.0) if(defined $schedule->random_start_percentage);
-        #allow a test to be scheduled anytime before the next scheduled run
-        $psc_task->schedule_slip('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
+        $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
         $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;

--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwtraceroute.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwtraceroute.pm
@@ -218,10 +218,7 @@ override 'build_pscheduler_task' => sub {
     
     #TODO: Support for more scheduling params
     if ($schedule->type eq "regular_intervals") {
-        $psc_task->schedule_repeat('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
-        $psc_task->schedule_randslip($schedule->random_start_percentage/100.0) if(defined $schedule->random_start_percentage);
-        #allow a test to be scheduled anytime before the next scheduled run
-        $psc_task->schedule_slip('PT' . $schedule->interval . 'S') if(defined $schedule->interval);
+        $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
         $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;

--- a/lib/perfSONAR_PS/RegularTesting/Tests/PSchedulerBase.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/PSchedulerBase.pm
@@ -229,15 +229,8 @@ override 'to_pscheduler' => sub {
         #schedule parameters
         my $interval;
         if ($schedule->type eq "regular_intervals") {
-            if(defined $schedule->interval){
-                $interval = $test->schedule()->interval;
-                $psc_task->schedule_repeat('PT' . $schedule->interval . 'S');
-                #allow a test to be scheduled anytime before the next scheduled run
-                $psc_task->schedule_slip('PT' . $schedule->interval . 'S');
-            }
-            my $randslip = .1;
-            $randslip = $schedule->random_start_percentage/100.0 if(defined $schedule->random_start_percentage);
-            $psc_task->schedule_randslip($randslip);
+            $interval = $schedule->interval;
+            $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
         }else{
             $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
             return;


### PR DESCRIPTION
These changes add support for sliprand to the meshconfig. Instead of using the old randslip option, these changes use slip along with the sliprand boolean field. It also provides for backward compatibility with the old random_start_percentage field if someone is still using that. By default it sets slip to a full test interval (i.e. repeat) and enables sliprand. This is very similar to the previous default. You can also explicitly set slip and slip_randmoze in a mesh to control these values, but it is not required.

Merge these when pscheduler has the required changes and you want to test with the mesh-config. No need to update any config files, the defaults should just do what we want and give a better distribution. 