### PR TITLE
Decode toolkit web params as UTF-8

### DIFF
--- a/lib/perfSONAR_PS/NPToolkit/WebService/Router.pm
+++ b/lib/perfSONAR_PS/NPToolkit/WebService/Router.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use JSON::XS;
 use Carp qw( cluck confess );
-use CGI qw( header );
+use CGI qw( header -utf8 );
 use Data::Dumper;
 
 sub new {


### PR DESCRIPTION
Fixes incorrect saving of Admin info with UTF-8 chars
on Ubuntu Xenial.