### PR TITLE
Parse output of ntpq instead of ntpdc (deprecated)

### DIFF
--- a/lib/perfSONAR_PS/Utils/Host.pm
+++ b/lib/perfSONAR_PS/Utils/Host.pm
@@ -516,6 +516,8 @@ sub get_ntp_info {
             $result->{host} = $host[1];
             $result->{refid} = $ntp_fields[1];
             $result->{stratum} = $ntp_fields[2];
+            $result->{type} = $ntp_fields[3];
+            $result->{when} = $ntp_fields[4];
             $result->{polling_interval} = $ntp_fields[5];
             $result->{reach} = $ntp_fields[6];
             $result->{delay} = $ntp_fields[7];

--- a/lib/perfSONAR_PS/Utils/Host.pm
+++ b/lib/perfSONAR_PS/Utils/Host.pm
@@ -503,7 +503,7 @@ sub discover_primary_address {
 sub get_ntp_info {
     my $ntp;
 
-    my $ntp_result = `/usr/sbin/ntpdc -p`;
+    my $ntp_result = `/usr/sbin/ntpq -p`;
 
     my @ntp_response = split /\n/, $ntp_result;
     
@@ -514,13 +514,13 @@ sub get_ntp_info {
             print @ntp_fields;
             my @host = split /\*/, $ntp_fields[0];
             $result->{host} = $host[1];
-            $result->{address} = $ntp_fields[1];
+            $result->{refid} = $ntp_fields[1];
             $result->{stratum} = $ntp_fields[2];
-            $result->{polling_interval} = $ntp_fields[3];
-            $result->{reach} = $ntp_fields[4];
-            $result->{delay} = $ntp_fields[5];
-            $result->{offset} = $ntp_fields[6];
-            $result->{dispersion} = $ntp_fields[7];
+            $result->{polling_interval} = $ntp_fields[5];
+            $result->{reach} = $ntp_fields[6];
+            $result->{delay} = $ntp_fields[7];
+            $result->{offset} = $ntp_fields[8];
+            $result->{dispersion} = $ntp_fields[9];
             last;
         }
     }


### PR DESCRIPTION
Example output:

```
$ /usr/sbin/ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
-ntp1.nl.uu.net  .PPS.            1 u   42   64    1   27.393   -0.183   0.395
+ntp1.oma.be     .MRS.            1 u   41   64    1   30.960   -0.448   0.114
+ntp2.inrim.it   .CTD.            1 u   40   64    1   22.735   -0.513   0.117
*ntp3.rrze.uni-e .PZF.            1 u   12   64    3   23.907   -0.293   0.139
-romulus.belnet. 193.190.198.43   2 u    8   64    1   30.303   -0.255   0.082
```