### PR TITLE
Fix $logger->warning calls

### DIFF
--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwctl.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwctl.pm
@@ -237,7 +237,7 @@ override 'build_pscheduler_task' => sub {
     if ($schedule->type eq "regular_intervals") {
         $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
-        $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
+        $logger->warn("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;
     }
     

--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwping.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwping.pm
@@ -220,7 +220,7 @@ override 'build_pscheduler_task' => sub {
     if ($schedule->type eq "regular_intervals") {
         $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
-        $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
+        $logger->warn("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;
     }
     

--- a/lib/perfSONAR_PS/RegularTesting/Tests/BwpingOwamp.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/BwpingOwamp.pm
@@ -195,7 +195,7 @@ override 'build_pscheduler_task' => sub {
     if ($schedule->type eq "regular_intervals") {
         $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
-        $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
+        $logger->warn("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;
     }
     

--- a/lib/perfSONAR_PS/RegularTesting/Tests/Bwtraceroute.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/Bwtraceroute.pm
@@ -224,7 +224,7 @@ override 'build_pscheduler_task' => sub {
     if ($schedule->type eq "regular_intervals") {
         $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
     }else{
-        $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
+        $logger->warn("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
         return;
     }
     

--- a/lib/perfSONAR_PS/RegularTesting/Tests/PSchedulerBase.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Tests/PSchedulerBase.pm
@@ -232,7 +232,7 @@ override 'to_pscheduler' => sub {
             $interval = $schedule->interval;
             $self->psc_test_interval(schedule => $schedule, psc_task => $psc_task);
         }else{
-            $logger->warning("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
+            $logger->warn("Schedule type " . $schedule->type . " not currently supported. Skipping test.");
             return;
         }
         


### PR DESCRIPTION
There is no warning() method in logger, only warn().