### PR TITLE
Fixes Problem adding test latencybg

### DIFF
--- a/lib/perfSONAR_PS/Client/PSConfig/Translators/MeshConfig/Config.pm
+++ b/lib/perfSONAR_PS/Client/PSConfig/Translators/MeshConfig/Config.pm
@@ -754,7 +754,7 @@ sub convert_psb_owamp {
     $psconfig_test->spec_param('dest', '{% address[1] %}');
     $psconfig_test->spec_param('source-node', '{% pscheduler_address[0] %}');
     $psconfig_test->spec_param('dest-node', '{% pscheduler_address[1] %}');
-    $psconfig_test->spec_param('flip', '{% flip %}');
+    $psconfig_test->spec_param('flip', JSON::true) if($test_params->{'flip'});
     #test params (int)
     $psconfig_test->spec_param('packet-count', int($test_params->{'sample_count'})) if($test_params->{'sample_count'});
     $psconfig_test->spec_param('ip-tos', int($test_params->{'tos_bits'})) if($test_params->{'tos_bits'});

--- a/lib/perfSONAR_PS/Client/PSConfig/Translators/MeshConfigTasks/Config.pm
+++ b/lib/perfSONAR_PS/Client/PSConfig/Translators/MeshConfigTasks/Config.pm
@@ -419,7 +419,7 @@ sub convert_powstream {
     $psconfig_test->spec_param('dest', '{% address[1] %}');
     $psconfig_test->spec_param('source-node', '{% pscheduler_address[0] %}');
     $psconfig_test->spec_param('dest-node', '{% pscheduler_address[1] %}');
-    $psconfig_test->spec_param('flip', '{% flip %}');
+    $psconfig_test->spec_param('flip', JSON::true) if($test_params->{'flip'});
     #test params (int)
     $psconfig_test->spec_param('packet-count', int($test_params->{'resolution'})) if($test_params->{'resolution'});
     $psconfig_test->spec_param('ip-tos', int($test_params->{'packet_tos_bits'})) if($test_params->{'packet_tos_bits'});
@@ -495,7 +495,7 @@ sub convert_bwping_owamp {
     $psconfig_test->spec_param('dest', '{% address[1] %}');
     $psconfig_test->spec_param('source-node', '{% pscheduler_address[0] %}');
     $psconfig_test->spec_param('dest-node', '{% pscheduler_address[1] %}');
-    $psconfig_test->spec_param('flip', '{% flip %}');
+    $psconfig_test->spec_param('flip', JSON::true) if($test_params->{'flip'});
     #test params (int)
     $psconfig_test->spec_param('packet-count', int($test_params->{'packet_count'})) if($test_params->{'packet_count'});
     $psconfig_test->spec_param('ip-tos', int($test_params->{'packet_tos_bits'})) if($test_params->{'packet_tos_bits'});


### PR DESCRIPTION
2018/04/17 10:06:13 WARN pid=1128 prog=perfSONAR_PS::PSConfig::PScheduler::Agent::_run_end line=218 guid=f6e89b26-7e0b-440c-a926-ca5d0b695ed8 msg=Problem adding test latencybg(pstest2.geant.carnet.hr->perfsonar-dev.grnoc.iu.edu), continuing with rest of config: HTTP/1.1 400 BAD REQUEST: Invalid test specification: At /flip: 0 is not of type 'boolean'