### PR TITLE
Fix JSON boolean handling for jessie and trusty #309

### DIFF
--- a/lib/perfSONAR_PS/RegularTesting/Utils/SerializableObject.pm
+++ b/lib/perfSONAR_PS/RegularTesting/Utils/SerializableObject.pm
@@ -164,7 +164,7 @@ sub parse_element_attribute {
 
         $parsed_value = \@array;
     }
-    elsif (JSON::is_bool($value)) {
+    elsif ($value eq '1' || $value eq '0') {
         if ($value) {
             $parsed_value = 1;
         }


### PR DESCRIPTION
Toolkit fails to load test configuration from disk.