### PR TITLE
pSConfig Issue #41: Fix case-sensitive mat-address comparison

### DIFF
--- a/lib/perfSONAR_PS/Client/PSConfig/Parsers/TaskGenerator.pm
+++ b/lib/perfSONAR_PS/Client/PSConfig/Parsers/TaskGenerator.pm
@@ -122,7 +122,7 @@ sub start {
     
     #set match addresses if any
     if(@{$self->match_addresses()} > 0){
-        my %match_addresses_map = map { $_ => 1 } @{$self->match_addresses()};
+        my %match_addresses_map = map { lc($_) => 1 } @{$self->match_addresses()};
         $self->_set_match_addresses_map(\%match_addresses_map);
     }else{
         $self->_set_match_addresses_map(undef);
@@ -445,10 +445,10 @@ sub _is_matching_address{
     
     if($address->_parent_address()){
         #if parent is set, then must match parent, otherwise no match
-        if($self->_match_addresses_map()->{$address->_parent_address()}){
+        if($self->_match_addresses_map()->{lc($address->_parent_address())}){
             return 1;
         }
-    }elsif($self->_match_addresses_map()->{$address->address()}){
+    }elsif($self->_match_addresses_map()->{lc($address->address())}){
         #no parent set, so match address
         return 1;
     }

--- a/t/client-psconfig-taskgenerator.t
+++ b/t/client-psconfig-taskgenerator.t
@@ -162,13 +162,13 @@ ok($tg->error());
 is($task->scheduled_by(0), 0); #valid scheduled_by 
 
 ####
-# Test setting match address
+# Test setting match address - including when case may not match
 ok($psconfig = new perfSONAR_PS::Client::PSConfig::Config(data => $config_obj));
 ok($task = $psconfig->task("example-task-throughput"));
 ok($tg = new perfSONAR_PS::Client::PSConfig::Parsers::TaskGenerator(
                                                             psconfig => $psconfig, 
                                                             task_name => "example-task-throughput", 
-                                                            match_addresses => [ "host-c.perfsonar.net" ]
+                                                            match_addresses => [ "HOST-C.perfsonar.net" ]
                                                         ));
 ok($tg->start());
 ok($tg->next());


### PR DESCRIPTION
Fixes a case-sensitive comparision of the match-address to the address in a template. This can cause issues for agents when reverse DNS contains uppercase letter but the template does not or vice-versa.