### PR TITLE
Fix reverse DNS result hash

### DIFF
--- a/lib/perfSONAR_PS/Utils/DNS.pm
+++ b/lib/perfSONAR_PS/Utils/DNS.pm
@@ -196,7 +196,7 @@ sub reverse_dns_multi {
     $end_time = time + $parameters->{timeout};
 
     my $res   = Net::DNS::Resolver->new;
-
+    my %results = ();
     my @socket_map = ();
 
     foreach my $addr (@{ $parameters->{addresses} }) {
@@ -206,9 +206,8 @@ sub reverse_dns_multi {
 
         my %pair = ( socket => $bgsock, address => $addr );
         push @socket_map, \%pair;
+        $results{$addr} = [];
     }
-
-    my %results = ();
 
     while(@socket_map) {
         my $sel = IO::Select->new();


### PR DESCRIPTION
Adding toolkit tests fails if a result is missing for some IP,
so make sure there is always at least an empty result.