### PR TITLE
Sort keys when saving lsregistrationdaemon.conf

### DIFF
--- a/lib/perfSONAR_PS/NPToolkit/Config/LSRegistrationDaemon.pm
+++ b/lib/perfSONAR_PS/NPToolkit/Config/LSRegistrationDaemon.pm
@@ -28,7 +28,7 @@ use Storable qw(store retrieve freeze thaw dclone);
 use Data::Dumper;
 use File::Basename qw(dirname basename);
 
-use Config::General qw(ParseConfig SaveConfigString);
+use Config::General qw(ParseConfig);
 use perfSONAR_PS::NPToolkit::ConfigManager::Utils qw( save_file restart_service );
 
 my %defaults = (
@@ -451,7 +451,7 @@ sub save {
     delete($config->{access_policy_notes});
     $config->{access_policy_notes} = $self->{ACCESS_POLICY_NOTES} if $self->{ACCESS_POLICY_NOTES};
 
-    my $content = SaveConfigString($config);
+    my $content = Config::General->new(-ConfigHash => $config, -SaveSorted => 1)->save_string();
 
     utf8::decode($content);
     my ($status, $res) = save_file( { file => $self->{CONFIG_FILE}, content => $content } );


### PR DESCRIPTION
Otherwise every change of configuration from Toolkit admin web
generates the keys in some random order and the file looks a mess.