### PR TITLE
Allow reading clock speed for Power machines

### DIFF
--- a/lib/perfSONAR_PS/Utils/Host.pm
+++ b/lib/perfSONAR_PS/Utils/Host.pm
@@ -602,6 +602,7 @@ sub get_processor_info {
         'CPU(s)' => 'cores',
     );
      my %cpuinfo_parse_map = (
+        'clock' => 'speed',
         'model name' => 'model_name',
     );
     my %cpuinfo = ();
@@ -629,7 +630,9 @@ sub get_processor_info {
             my @cols = split /\s*:\s*/, $line;
             next if(@cols != 2);
             if($cpuinfo_parse_map{$cols[0]}){
-                $cpuinfo{_sanitize($cpuinfo_parse_map{$cols[0]})} = _sanitize($cols[1]);
+                my $val = _sanitize($cols[1]);
+                $val =~ s/MHz$//;
+                $cpuinfo{_sanitize($cpuinfo_parse_map{$cols[0]})} = $val;
             }
         }
     }


### PR DESCRIPTION
Use of uninitialized value in multiplication (*) at /usr/share/perl5/perfSONAR_PS/NPToolkit/DataService/Host.pm line 378.

$ cat /proc/cpuinfo
processor       : 0
cpu             : POWER8 (architected), altivec supported
clock           : 1000.000000MHz
revision        : 2.0 (pvr 004d 0200)

processor       : 1
cpu             : POWER8 (architected), altivec supported
clock           : 1000.000000MHz
revision        : 2.0 (pvr 004d 0200)

timebase        : 512000000
platform        : pSeries
model           : IBM pSeries (emulated by qemu)
machine         : CHRP IBM pSeries (emulated by qemu)