### PR TITLE
Enhance functions for multi-OS support

### DIFF
--- a/libperfsonar/libperfsonar/lib/perfSONAR_PS/NPToolkit/Services/Base.pm
+++ b/libperfsonar/libperfsonar/lib/perfSONAR_PS/NPToolkit/Services/Base.pm
@@ -6,7 +6,6 @@ use warnings;
 use Log::Log4perl qw(:easy);
 use File::Spec;
 use fields 'LOGGER', 'INIT_SCRIPT', 'PID_FILES', 'PROCESS_NAMES', 'DESCRIPTION', 'CAN_DISABLE', 'REGULAR_RESTART', 'PACKAGE_NAMES', 'SYSTEMD_SERVICES';
-use RPM2;
 
 sub new {
     my ( $package ) = @_;
@@ -47,18 +46,21 @@ sub init {
 
 sub package_version {
     my ($self) = @_;
-
     my $version;
-    if ($self->{PACKAGE_NAMES}) {
-        my $min;
 
+    my sub command_exists {
+        my ($cmd) = @_;
+        return !system("which $cmd > /dev/null 2>&1");
+    }
+
+    if (command_exists('rpm')) {
+        eval { require RPM2; };
+        my $min;
         if (my $db = RPM2->open_rpm_db()) {
             foreach my $package_name (@{ $self->{PACKAGE_NAMES} }) {
                 my @packages = $db->find_by_name($package_name);
-    
                 foreach my $package (@packages) {
                     $min = $package unless $min;
-    
                     my $result = ($package <=> $min);
                     if ($result < 0) {
                         $min = $package;
@@ -66,8 +68,21 @@ sub package_version {
                 }
             }
         }
-
-        $version = $min->version."-".$min->release if $min;
+        $version = $min->version . "-" . $min->release if $min;
+    }
+    elsif (command_exists('dpkg')) {
+        eval { require Dpkg::Version; Dpkg::Version->import(qw(dpkg_version_compare)); };
+        my $min_version;
+        foreach my $package_name (@{ $self->{PACKAGE_NAMES} }) {
+            my $current_version = `dpkg-query -W -f='\${Version}' $package_name 2>/dev/null`;
+            chomp $current_version;
+            if ($current_version) {
+                if (!defined $min_version || dpkg_version_compare($current_version, $min_version) < 0) {
+                    $min_version = $current_version;
+                }
+            }
+        }
+        $version = $min_version;
     }
 
     return $version;

--- a/libperfsonar/libperfsonar/lib/perfSONAR_PS/Web/Sidebar.pm
+++ b/libperfsonar/libperfsonar/lib/perfSONAR_PS/Web/Sidebar.pm
@@ -9,8 +9,6 @@ use Time::HiRes qw( time );
 use Params::Validate;
 use Data::Dumper;
 
-use RPM2;
-
 use perfSONAR_PS::NPToolkit::Config::AdministrativeInfo;
 
 use perfSONAR_PS::NPToolkit::Services::ServicesMap qw(get_service_object);
@@ -36,15 +34,29 @@ sub set_sidebar_vars {
     $vars->{ntp_nav_class} = "warning" unless $ntpinfo->is_synced();
 
     my $cacti_available;
-    # TODO-debian: this will need a patch
-    if (my $db = RPM2->open_rpm_db()) {
-       my @packages = $db->find_by_name("cacti");
- 
-       $cacti_available = 1 if scalar(@packages) > 0;
+
+    my sub command_exists {
+        my ($cmd) = @_;
+        return !system("which $cmd > /dev/null 2>&1");
     }
 
-    $vars->{cacti_available} = $cacti_available;
-  
+    if (command_exists('rpm')) {
+        eval { require RPM2; };
+
+        if (my $db = RPM2->open_rpm_db()) {
+           my @packages = $db->find_by_name("cacti");
+
+           $cacti_available = 1 if scalar(@packages) > 0;
+        }
+
+        $vars->{cacti_available} = $cacti_available;
+    }
+    elsif (command_exists('dpkg')) {
+        if ( system("dpkg -s cacti > /dev/null 2>&1") == 0 ) {
+            $cacti_available = 1;
+        }
+    }
+
     return $vars;
 
 }


### PR DESCRIPTION
The package_version, set_sidebar_vars functions were previously implemented only for RHEL-based systems, relying exclusively on the RPM2 module.

This change introduces OS detection to provide multi-distro support. It now correctly retrieves package versions on Debian-based systems by using dpkg, while maintaining the existing RPM functionality.